### PR TITLE
manitest

### DIFF
--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -73,7 +73,7 @@ def parse_args(args):
     )
     cmd_gpg_verify.add_argument(
         "--gnupg-home",
-        help=("A valid GNUPG home directory. (default: the GNUPG default, usually ~/.gnupg)"),
+        help=("A valid GnuPG home directory. (default: the GnuPG default, usually ~/.gnupg)"),
         required=False,
         metavar="GNUPG_HOME",
         dest="gnupg_home",
@@ -110,7 +110,7 @@ def parse_args(args):
     )
     cmd_gpg_sign.add_argument(
         "--gnupg-home",
-        help=("A valid GNUPG home directory. (default: the GNUPG default, usually ~/.gnupg)"),
+        help=("A valid GnuPG home directory. (default: the GnuPG default, usually ~/.gnupg)"),
         required=False,
         metavar="GNUPG_HOME",
         dest="gnupg_home",
@@ -217,7 +217,7 @@ def gpg_verify(args):
         return 1
 
     if args.gnupg_home is not None and not os.path.isdir(args.gnupg_home):
-        _error(f"Specified GNUPG home is not a directory: {args.gnupg_home}")
+        _error(f"Specified GnuPG home is not a directory: {args.gnupg_home}")
         return 1
 
     verifier = GPGVerifier(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,3 +136,17 @@ def signed_project_broken_manifest(
     Sign a project that has a broken manifest.
     """
     yield _sign_project(gpg_home_with_secret_key, unsigned_project_with_broken_checksum_manifest)
+
+
+@pytest.fixture
+def signed_project_missing_manifest(
+    gpg_home_with_secret_key,
+    unsigned_project_with_checksum_manifest,
+):
+    """
+    Sign a project that has a broken manifest.
+    """
+    (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
+    manifest = project / ".ansible-sign" / "sha256sum.txt"
+    os.remove(manifest)
+    yield (project, gpghome)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,22 @@ def test_gpg_validate_manifest_with_keyring(capsys, signed_project_and_gpg):
     assert rc in (None, 0)
 
 
+def test_gpg_validate_broken_manifest(capsys, signed_project_broken_manifest):
+    project_root = signed_project_broken_manifest[0]
+    gpg_home = signed_project_broken_manifest[1]
+    keyring = os.path.join(gpg_home, "pubring.kbx")
+    args = [
+        "project",
+        "gpg-verify",
+        f"--keyring={keyring}",
+        str(project_root),
+    ]
+    rc = main(args)
+    captured = capsys.readouterr()
+    assert "Invalid line encountered in checksum manifest" in captured.out
+    assert rc == 1
+
+
 @pytest.mark.parametrize(
     "use_passphrase",
     [True, False],


### PR DESCRIPTION
- tests: add fixture for signing a broken manifest file and test gpg-verify in this situation
- cli: GnuPG, not GNUPG
- tests: more coverage for CLI error scenarios
