### PR TITLE
even more CLI coverage work

### DIFF
--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -167,13 +167,18 @@ def _note(msg):
 
 
 def validate_checksum(project_root):
+    """
+    Validate a checksum manifest file. Print a pretty message and return an
+    appropriate exit code.
+
+    NOTE that this function does not actually check the path for existence, it
+    leaves that to the caller (which in nearly all cases would need to do so
+    anyway). This function will throw FileNotFoundError if the manifest does not
+    exist.
+    """
     differ = DistlibManifestChecksumFileExistenceDiffer
     checksum = ChecksumFile(project_root, differ=differ)
     checksum_path = os.path.join(project_root, ".ansible-sign", "sha256sum.txt")
-
-    if not os.path.exists(checksum_path):
-        _error(f"Checksum file does not exist: {checksum_path}")
-        return 1
 
     checksum_file_contents = open(checksum_path, "r").read()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,3 +182,17 @@ def signed_project_missing_manifest(
     manifest = project / ".ansible-sign" / "sha256sum.txt"
     os.remove(manifest)
     yield (project, gpghome)
+
+
+@pytest.fixture
+def signed_project_with_different_gpg_home(
+    gpg_home_with_secret_key,
+    gpg_home_with_hao_pubkey,
+    unsigned_project_with_checksum_manifest,
+):
+    """
+    Sign a project but 'lose' the key it was signed with by returning an
+    unrelated gnupg home directory.
+    """
+    (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
+    yield (project, gpg_home_with_hao_pubkey)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,12 +130,14 @@ def test_main_with_pubkey_in_keyring(capsys, gpg_home_with_hao_pubkey, args, exp
         ("signed_project_broken_manifest", "Invalid line encountered in checksum manifest", "", 1),
         ("signed_project_missing_manifest", "Checksum manifest file does not exist:", "", 1),
         ("signed_project_modified_manifest", "Checksum validation failed.", "", 2),
+        ("signed_project_with_different_gpg_home", "Re-run with the global --debug flag", "", 3),
     ],
     ids=[
         "valid checksum file and signature",
         "valid signature but broken checksum file",
         "missing checksum file entirely",
         "checksum file with wrong hashes",
+        "matching pubkey does not exist in gpg home",
     ],
 )
 def test_gpg_verify_manifest_scenario(capsys, request, project_fixture, exp_stdout_substr, exp_stderr_substr, exp_rc):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,11 +129,13 @@ def test_main_with_pubkey_in_keyring(capsys, gpg_home_with_hao_pubkey, args, exp
         ("signed_project_and_gpg", "GPG signature verification succeeded", "", 0),
         ("signed_project_broken_manifest", "Invalid line encountered in checksum manifest", "", 1),
         ("signed_project_missing_manifest", "Checksum manifest file does not exist:", "", 1),
+        ("signed_project_modified_manifest", "Checksum validation failed.", "", 2),
     ],
     ids=[
         "valid checksum file and signature",
         "valid signature but broken checksum file",
         "missing checksum file entirely",
+        "checksum file with wrong hashes",
     ],
 )
 def test_gpg_verify_manifest_scenario(capsys, request, project_fixture, exp_stdout_substr, exp_stderr_substr, exp_rc):


### PR DESCRIPTION
- cli: remove now-unreachable code path asserting the existence of the checksum file
- tests: coverage for case where checksum manifest hashes are wrong before signing
- tests: coverage for gpg pubkey mismatch/not found during gpg-verify
