### PR TITLE
cli: Optionally take GPG passphrase from env var

### DIFF
--- a/docs/rundown.rst
+++ b/docs/rundown.rst
@@ -185,6 +185,10 @@ GitHub Actions secret, and import that into GnuPG in the CI environment. One
 could then run through the signing workflow above within the normal CI
 workflow/container/environment.
 
+When signing a project using GPG, the environment variable
+``ANSIBLE_SIGN_GPG_PASSPHRASE`` can be set to the passphrase of the signing
+key. This can be injected (and masked/secured) in a CI pipeline.
+
 ``ansible-sign`` will return with a different exit-code depending on the
 scenario at hand, both during signing and verification. This can also be useful
 in the context of CI and automation, as a CI environment can act differently

--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -296,7 +296,11 @@ class AnsibleSignCLI:
         # Do they need a passphrase?
         passphrase = None
         if self.args.prompt_passphrase:
+            self.logger.debug("Prompting for GPG key passphrase")
             passphrase = getpass.getpass("GPG Key Passphrase: ")
+        elif "ANSIBLE_SIGN_GPG_PASSPHRASE" in os.environ:
+            self.logger.debug("Taking GPG key passphrase from ANSIBLE_SIGN_GPG_PASSPHRASE env var")
+            passphrase = os.environ["ANSIBLE_SIGN_GPG_PASSPHRASE"]
 
         signature_path = os.path.join(self.args.project_root, ".ansible-sign", "sha256sum.txt.sig")
         signer = GPGSigner(


### PR DESCRIPTION
- This allows CI pipelines (and QE friends) to automate the signing of
  projects without needing to pass in the passphrase via STDIN or
  GnuPG's pinentry infrastructure.

Signed-off-by: Rick Elrod <rick@elrod.me>

This is based on `main` for now, ~~I will update #18 to roll in the changes after this gets merged~~ I will update this after #18 merges.