### PR TITLE
Don't push docs site on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Run tests
         run: tox -e py3
+
+      - name: Ensure docs build
+        run: tox -e docs
   linters:
     name: Linters
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@
 name: ansible-sign docs
 on:  # yamllint disable-line rule:truthy
   push:
+    branches:
+      - main
 
 jobs:
   docs:


### PR DESCRIPTION
- Limit docs workflow to main branch pushes
- Add `tox -e docs` to ci, though, to ensure that docs builds are still
  successful.

Signed-off-by: Rick Elrod <rick@elrod.me>