### PR TITLE
[DRAFT] Make ChecksumMismatch prettier, CLI and __str__

### DIFF
--- a/src/ansible_sign/checksum/base.py
+++ b/src/ansible_sign/checksum/base.py
@@ -11,7 +11,33 @@ class NoDifferException(Exception):
 
 
 class ChecksumMismatch(Exception):
-    pass
+    def __init__(self, msg, differences={}):
+        super().__init__(msg)
+        self.msg = msg
+        self.differences = differences
+
+    def __str__(self):
+        """
+        This *must* be something human-readable, it is currently used in the AWX
+        action plugin on project sync when validation fails.
+        """
+        out = self.msg
+        extra_info = ''
+        if 'changes' in self.differences and self.differences['changes']:
+            extra_info += f"Files changed: {', '.join(self.differences['changes'])}"
+
+        if 'added' in self.differences and self.differences['added']:
+            sep = "; " if extra_info else ""
+            extra_info += f"{sep}Files added: {', '.join(self.differences['added'])}"
+
+        if 'removed' in self.differences and self.differences['removed']:
+            sep = "; " if extra_info else ""
+            extra_info += f"{sep}Files removed: {', '.join(self.differences['removed'])}"
+
+        if extra_info:
+            return f"{out}. {extra_info}"
+
+        return out
 
 
 class ChecksumFile:
@@ -166,7 +192,7 @@ class ChecksumFile:
             # If there are any differences in existing paths, fail the check...
             differences = self.diff(parsed_manifest_dct.keys())
             if differences["added"] or differences["removed"]:
-                raise ChecksumMismatch(differences)
+                raise ChecksumMismatch("Files were added or removed", differences)
 
         recalculated = self.calculate_checksums_from_root(verifying=True)
         mismatches = set()
@@ -174,6 +200,7 @@ class ChecksumFile:
             if recalculated[parsed_path] != parsed_checksum:
                 mismatches.add(parsed_path)
         if mismatches:
-            raise ChecksumMismatch(f"Checksum mismatch: {', '.join(mismatches)}")
+            differences = {'changes': list(mismatches)}
+            raise ChecksumMismatch("Checksum mismatch", differences)
 
         return True

--- a/src/ansible_sign/checksum/base.py
+++ b/src/ansible_sign/checksum/base.py
@@ -22,15 +22,15 @@ class ChecksumMismatch(Exception):
         action plugin on project sync when validation fails.
         """
         out = self.msg
-        extra_info = ''
-        if 'changes' in self.differences and self.differences['changes']:
+        extra_info = ""
+        if "changes" in self.differences and self.differences["changes"]:
             extra_info += f"Files changed: {', '.join(self.differences['changes'])}"
 
-        if 'added' in self.differences and self.differences['added']:
+        if "added" in self.differences and self.differences["added"]:
             sep = "; " if extra_info else ""
             extra_info += f"{sep}Files added: {', '.join(self.differences['added'])}"
 
-        if 'removed' in self.differences and self.differences['removed']:
+        if "removed" in self.differences and self.differences["removed"]:
             sep = "; " if extra_info else ""
             extra_info += f"{sep}Files removed: {', '.join(self.differences['removed'])}"
 
@@ -200,7 +200,7 @@ class ChecksumFile:
             if recalculated[parsed_path] != parsed_checksum:
                 mismatches.add(parsed_path)
         if mismatches:
-            differences = {'changes': list(mismatches)}
+            differences = {"changes": list(mismatches)}
             raise ChecksumMismatch("Checksum mismatch", differences)
 
         return True

--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -237,13 +237,13 @@ class AnsibleSignCLI:
             self._error("Checksum validation failed.")
             if e.differences:
                 differences = (
-                    ('added', 'added'),
-                    ('removed', 'removed'),
-                    ('changes', 'changed'),
+                    ("added", "added"),
+                    ("removed", "removed"),
+                    ("changes", "changed"),
                 )
                 for key, verb in differences:
                     if key in e.differences and e.differences[key]:
-                        self._note(f'Files {verb}:')
+                        self._note(f"Files {verb}:")
                         num_changes = len(e.differences[key])
                         if self.args.no_truncate:
                             truncate_at = num_changes
@@ -252,9 +252,9 @@ class AnsibleSignCLI:
                             truncate_at = 6
                             truncated = num_changes > truncate_at
                         for path in e.differences[key][0:(truncate_at)]:
-                            self._note(f'  - {path}')
+                            self._note(f"  - {path}")
                         if truncated:
-                            self._note(f'  [{num_changes - truncate_at} lines omitted, use --no-truncate to see all...]')
+                            self._note(f"  [{num_changes - truncate_at} lines omitted, use --no-truncate to see all...]")
             return 2
         except FileNotFoundError as e:
             if os.path.islink(e.filename):

--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -110,6 +110,14 @@ class AnsibleSignCLI:
             default=None,
         )
         cmd_gpg_verify.add_argument(
+            "--no-truncate",
+            help="Disable truncation of file listings when enumerating file differences",
+            required=False,
+            dest="no_truncate",
+            default=False,
+            action="store_true",
+        )
+        cmd_gpg_verify.add_argument(
             "project_root",
             help="The directory containing the files being validated and verified",
             metavar="PROJECT_ROOT",
@@ -227,7 +235,26 @@ class AnsibleSignCLI:
             checksum.verify(manifest, diff=True)
         except ChecksumMismatch as e:
             self._error("Checksum validation failed.")
-            self._error(str(e))
+            if e.differences:
+                differences = (
+                    ('added', 'added'),
+                    ('removed', 'removed'),
+                    ('changes', 'changed'),
+                )
+                for key, verb in differences:
+                    if key in e.differences and e.differences[key]:
+                        self._note(f'Files {verb}:')
+                        num_changes = len(e.differences[key])
+                        if self.args.no_truncate:
+                            truncate_at = num_changes
+                            truncated = False
+                        else:
+                            truncate_at = 6
+                            truncated = num_changes > truncate_at
+                        for path in e.differences[key][0:(truncate_at)]:
+                            self._note(f'  - {path}')
+                        if truncated:
+                            self._note(f'  [{num_changes - truncate_at} lines omitted, use --no-truncate to see all...]')
             return 2
         except FileNotFoundError as e:
             if os.path.islink(e.filename):

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -116,19 +116,19 @@ def test_parse_manifest_empty():
     [
         (
             "files-added",
-            "{'added': ['hello2', 'hello3'], 'removed': []}",
+            "Files were added or removed. Files added: hello2, hello3",
         ),
         (
             "files-added-removed",
-            "{'added': ['hello2', 'hello3'], 'removed': ['hello1']}",
+            "Files were added or removed. Files added: hello2, hello3; Files removed: hello1",
         ),
         (
             "files-removed",
-            "{'added': [], 'removed': ['hello1']}",
+            "Files were added or removed. Files removed: hello1",
         ),
         (
             "files-changed",
-            "Checksum mismatch: hello1",
+            "Checksum mismatch. Files changed: hello1",
         ),
         (
             "success",
@@ -136,7 +136,7 @@ def test_parse_manifest_empty():
         ),
     ],
 )
-def test_directory_diff(
+def test_directory_diff_human_readable_exc(
     fixture,
     diff_output,
 ):


### PR DESCRIPTION
**DRAFT for these reasons:**
- This needs to be tested with AWX (since it uses our `ChecksumMismatch#__str__` in its output)
- I would like to add tests for the new CLI output/truncation stuff.

------

Change:
- [checksum] Make ChecksumMismatch carry differences as a class parameter so that when things like the CLI render it, they can use that information.

- [checksum] Make ChecksumMismatch implement `__str__` and give a pretter error. AWX currently uses str(exc) to render the errors, so this is a UX improvement there as well.

- [cli] Make the UI show these errors nicer as well. Now it will truncate the listing of files by default to avoid flooding the user's screen if they forgot (for example) to exclude their .git directory. A new flag, --no-truncate, is added to disable this truncation. Also, now the files are listed out in a readable way, one per line, rather than as a literal Python dictionary representation.

Test Plan:
- Updated tests for the new `__str__` output

Signed-off-by: Rick Elrod <rick@elrod.me>