### PR TITLE
cli: specify metavar for content_type

### DIFF
--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -79,7 +79,7 @@ class AnsibleSignCLI:
         )
 
         # Future-proofing for future content types.
-        content_type_parser = parser.add_subparsers(required=True, dest="content_type")
+        content_type_parser = parser.add_subparsers(required=True, dest="content_type", metavar="CONTENT_TYPE")
 
         project = content_type_parser.add_parser(
             "project",


### PR DESCRIPTION
This is just tiny UX enhancement to make it easier to determine what `project` refers to.