### PR TITLE
Prettier error on MANIFEST.in parse failure

### DIFF
--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -1,4 +1,5 @@
 import argparse
+from distlib.manifest import DistlibException
 import getpass
 import logging
 import os
@@ -169,6 +170,12 @@ class AnsibleSignCLI:
                 self._note("See the ansible-sign documentation for more information.")
                 return False
             raise e
+        except DistlibException as e:
+            self._error(f"An error was encountered while parsing MANIFEST.in: {e}")
+            if self.args.loglevel != logging.DEBUG:
+                self._note("You can use the --debug global flag to view the full traceback.")
+            self.logger.debug(e, exc_info=e)
+            return False
         for warning in checksum.warnings:
             self._warn(warning)
         self.logger.debug(
@@ -239,6 +246,12 @@ class AnsibleSignCLI:
                 self._note("If you are attempting to verify a signed project, please ensure that the project directory includes this file after signing.")
                 self._note("See the ansible-sign documentation for more information.")
                 return 1
+        except DistlibException as e:
+            self._error(f"An error was encountered while parsing MANIFEST.in: {e}")
+            if self.args.loglevel != logging.DEBUG:
+                self._note("You can use the --debug global flag to view the full traceback.")
+            self.logger.debug(e, exc_info=e)
+            return 1
 
         for warning in checksum.warnings:
             self._warn(warning)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,7 +203,7 @@ def signed_project_missing_manifest(
     unsigned_project_with_checksum_manifest,
 ):
     """
-    Sign a project that has a broken manifest.
+    Sign a project that has a missing manifest.
     """
     (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
     manifest = project / ".ansible-sign" / "sha256sum.txt"
@@ -223,3 +223,18 @@ def signed_project_with_different_gpg_home(
     """
     (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
     yield (project, gpg_home_with_hao_pubkey)
+
+
+@pytest.fixture
+def signed_project_broken_manifest_in(
+    gpg_home_with_secret_key,
+    unsigned_project_with_checksum_manifest,
+):
+    """
+    Sign a project but then break its MANIFEST.in.
+    """
+    (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
+    manifest_in = project / "MANIFEST.in"
+    with open(manifest_in, "w") as f:
+        f.write("invalid-directive foo bar\n")
+    yield (project, gpghome)

--- a/tests/fixtures/checksum/manifest-syntax-error/MANIFEST.in
+++ b/tests/fixtures/checksum/manifest-syntax-error/MANIFEST.in
@@ -1,0 +1,1 @@
+invalid-directive foo bar

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,16 @@ __license__ = "MIT"
         (
             [
                 "project",
+                "gpg-sign",
+                "tests/fixtures/checksum/manifest-syntax-error",
+            ],
+            "An error was encountered while parsing MANIFEST.in: unknown action 'invalid-directive'",
+            "",
+            1,
+        ),
+        (
+            [
+                "project",
                 "gpg-verify",
                 "tests/fixtures/checksum/manifest-success",
             ],
@@ -124,6 +134,7 @@ def test_main_with_pubkey_in_keyring(capsys, gpg_home_with_hao_pubkey, args, exp
         ("signed_project_missing_manifest", "Checksum manifest file does not exist:", "", 1),
         ("signed_project_modified_manifest", "Checksum validation failed.", "", 2),
         ("signed_project_with_different_gpg_home", "Re-run with the global --debug flag", "", 3),
+        ("signed_project_broken_manifest_in", "An error was encountered while parsing MANIFEST.in: unknown action 'invalid-directive'", "", 1),
     ],
     ids=[
         "valid checksum file and signature",
@@ -131,6 +142,7 @@ def test_main_with_pubkey_in_keyring(capsys, gpg_home_with_hao_pubkey, args, exp
         "missing checksum file entirely",
         "checksum file with wrong hashes",
         "matching pubkey does not exist in gpg home",
+        "broken MANIFEST.in after signing",
     ],
 )
 def test_gpg_verify_manifest_scenario(capsys, request, project_fixture, exp_stdout_substr, exp_stderr_substr, exp_rc):


### PR DESCRIPTION
Only show a traceback in --debug mode

Fixes #29

Signed-off-by: Rick Elrod <rick@elrod.me>

------

(As an aside, some of these error handling cases are getting repetitive in cli.py, and can probably be refactored a bit to avoid the almost-copy-paste - but that can be addressed in another PR later on.)

------

## Before

```
rick@mba manifest-syntax-error % ansible-sign project gpg-sign .
Traceback (most recent call last):
  File "/Users/rick/.py310venv/bin/ansible-sign", line 8, in <module>
    sys.exit(run())
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/cli.py", line 361, in run
    return main(sys.argv[1:])
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/cli.py", line 351, in main
    exitcode = cli.run_command()
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/cli.py", line 45, in run_command
    return self.args.func()
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/cli.py", line 308, in gpg_sign
    checksum_file_contents = self._generate_checksum_manifest()
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/cli.py", line 160, in _generate_checksum_manifest
    manifest = checksum.generate_gnu_style()
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/checksum/base.py", line 119, in generate_gnu_style
    calculated = self.calculate_checksums_from_root(verifying=False)
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/checksum/base.py", line 147, in calculate_checksums_from_root
    for path in self.differ.list_files(verifying=verifying):
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/checksum/differ/base.py", line 51, in list_files
    gathered = self.gather_files(verifying=verifying)
  File "/Users/rick/dev/ansible/ansible-signatory/src/ansible_sign/checksum/differ/distlib_manifest.py", line 42, in gather_files
    manifest.process_directive(line)
  File "/Users/rick/.py310venv/lib/python3.10/site-packages/distlib/manifest.py", line 145, in process_directive
    action, patterns, thedir, dirpattern = self._parse_directive(directive)
  File "/Users/rick/.py310venv/lib/python3.10/site-packages/distlib/manifest.py", line 252, in _parse_directive
    raise DistlibException('unknown action %r' % action)
distlib.DistlibException: unknown action 'invalid-directive'
```

## After

<img width="697" alt="image" src="https://user-images.githubusercontent.com/43930/197269034-e6239cfb-ca5c-4b6f-aab8-257646afddf2.png">
