### PR TITLE
Exclude virtualenv directories from flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -106,6 +106,10 @@ exclude =
     dist
     .eggs
     docs/conf.py
+    venv
+    .venv
+    env
+    .env
 
 [pyscaffold]
 # PyScaffold's parameters when the project was created.


### PR DESCRIPTION
Ignore common virtualenv directory patterns from flake8 config to reduce processing time.