### PR TITLE
Make github actions pipelines pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
             os: ubuntu-latest
           - python: "3.10"
             os: ubuntu-latest
+          - python: "3.11"
+            os: ubuntu-latest
+          - python: "3.12"
+            os: ubuntu-latest
           - python: "3.10"
             os: macos-latest
     steps:
@@ -31,7 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install system packages
+      - name: Install system packages (linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update && \
@@ -39,12 +43,15 @@ jobs:
             tmux \
             ;
 
-      - name: Install system packages
+      - name: Install system packages (macos)
         if: matrix.os == 'macos-latest'
         run: |
           brew install \
             tmux \
+            gpg \
             ;
+          which -a gpg
+          gpg --version
 
       - name: Install tox
         run: pip install tox

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
     PyScaffold helps you to put up the scaffold of your new Python project.
     Learn more under: https://pyscaffold.org/
 """
+
 from setuptools import setup
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,11 @@ import shutil
 from ansible_sign.signing import GPGSigner
 
 
+if gnupg.__version__ >= "1.0":
+    # https://stackoverflow.com/q/35028852/99834
+    pytest.exit("Unsupported gnupg library found, repair it with: pip3 uninstall -y gnupg && pip3 install python-gnupg")
+
+
 @pytest.fixture
 def tmux_session(request):
     """

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,4 +3,4 @@ pytest
 pytest-mock
 flake8
 yamllint
-black
+black>=24.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ deps =
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
+    CI
+    GITHUB_*
     HOME
     SETUPTOOLS_*
 extras =


### PR DESCRIPTION
- black fixes (includes security)
- enable testing with py311, py312
- marked with xfails two macos specific tests (only for GHA)
