### PR TITLE
Docsite: add Community and Contributing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Documentation can be found on [ansible-sign.readthedocs.io](https://ansible.read
 including a
 [rundown/tutorial](https://ansible.readthedocs.io/projects/sign/en/latest/rundown.html)
 explaining how to use the CLI for basic project signing and verification.
+
+## Community
+
+Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/sign/en/latest/community.html) to learn how to join the conversation.

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ explaining how to use the CLI for basic project signing and verification.
 
 ## Community
 
-Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/sign/en/latest/community.html) to learn how to join the conversation.
+Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/sign/en/latest/community.html) join the conversation.

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,0 +1,26 @@
+.. _community:
+
+=========
+Community
+=========
+
+We welcome your feedback, questions and ideas. Here's how to reach the community.
+
+Code of Conduct
+===============
+
+All communication and interactions in the Ansible community are governed by the `Ansible code of conduct <https://docs.ansible.com/ansible/devel/community/code_of_conduct.html>`_. Please read and abide by it!
+Reach out to our community team at `codeofconduct@ansible.com <mailto:codeofconduct@ansible.com>`_ if you have any questions or need assistance.
+
+Ansible Forum
+=============
+
+Join the `Ansible Forum <https://forum.ansible.com>`_, the default communication platform for questions and help, development discussions, events, and much more. `Register <https://forum.ansible.com/signup?>`_ to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+
+* `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example `ansible-sign`.
+* `Posts tagged with 'ansible-sign' <https://forum.ansible.com/tag/ansible-sign>`_: subscribe to participate in project-related conversations.
+* `Bullhorn newsletter <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
+* `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
+* `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
+
+For more information on the forum navigation, see `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ post.

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -23,4 +23,4 @@ Join the `Ansible Forum <https://forum.ansible.com>`_, the default communication
 * `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
 * `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
 
-For more information on the forum navigation, see `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ post.
+See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,6 +4,6 @@ Contributing
 
 .. note::
 
-  Need help or want to discuss the project? See the :ref:`Community guide<community>` to join the conversation!
+   Need help or want to discuss the project? See the :ref:`Community guide<community>` to join the conversation!
 
 See out `Contributing guide <https://github.com/ansible/ansible-sign/blob/main/CONTRIBUTING.md>`_ to learn how to contribute to ``ansible-sign``!

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,6 +4,6 @@ Contributing
 
 .. note::
 
-  Need help or want to discuss the project? See the :ref:`Community guide<community>` to learn how to join the conversation!
+  Need help or want to discuss the project? See the :ref:`Community guide<community>` join the conversation!
 
 See out `Contributing guide <https://github.com/ansible/ansible-sign/blob/main/CONTRIBUTING.md>`_ to learn how to contribute to ``ansible-sign``!

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,6 +4,6 @@ Contributing
 
 .. note::
 
-  Need help or want to discuss the project? See the :ref:`Community guide<community>` join the conversation!
+  Need help or want to discuss the project? See the :ref:`Community guide<community>` to join the conversation!
 
 See out `Contributing guide <https://github.com/ansible/ansible-sign/blob/main/CONTRIBUTING.md>`_ to learn how to contribute to ``ansible-sign``!

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,9 @@
+============
+Contributing
+============
+
+.. note::
+
+  Need help or want to discuss the project? See the :ref:`Community guide<community>` to learn how to join the conversation!
+
+See out `Contributing guide <https://github.com/ansible/ansible-sign/blob/main/CONTRIBUTING.md>`_ to learn how to contribute to ``ansible-sign``!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,10 @@ ansible-sign
 This is the documentation for the **ansible-sign** utility used for signing and
 verifying Ansible content.
 
+.. note::
+
+  Need help or want to discuss the project? See the :ref:`Community guide<community>` to learn how to join the conversation!
+
 Contents
 ========
 
@@ -12,6 +16,7 @@ Contents
    :maxdepth: 2
 
    Overview <readme>
+   Community <community>
    Contributions & Help <contributing>
    License <license>
    Authors <authors>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ verifying Ansible content.
 
 .. note::
 
-  Need help or want to discuss the project? See the :ref:`Community guide<community>` to join the conversation!
+   Need help or want to discuss the project? See the :ref:`Community guide<community>` to join the conversation!
 
 Contents
 ========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ verifying Ansible content.
 
 .. note::
 
-  Need help or want to discuss the project? See the :ref:`Community guide<community>` to learn how to join the conversation!
+  Need help or want to discuss the project? See the :ref:`Community guide<community>` to join the conversation!
 
 Contents
 ========


### PR DESCRIPTION
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thank you